### PR TITLE
Remove show_all for GTK4 extensions preferences

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -138,7 +138,6 @@ const settingsWidgets = new GObject.Class({
 
 function buildPrefsWidget() {
 	const widgets = new settingsWidgets();
-	widgets.show_all();
 
 	return widgets;
 }


### PR DESCRIPTION
The preferences panel for Tray Icons: Reloaded doesn't work in GNOME 40 as show_all() is no longer supported by GTK4 due to all widgets being visible by default. However this might break the preferences panel for < 40 users, I haven't been able to test that though.

From my testing, this is the only change required for running Tray Icons: Reloaded on GNOME 40. 