### PR TITLE
Add multiple shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,8 @@
 {
-	"shell-version": ["41"],
+	"shell-version": [
+		"40",
+		"41"
+	],
 	"uuid": "trayIconsReloaded@selfmade.pl",
 	"url": "https://github.com/MartinPL/Tray-Icons-Reloaded",
 	"version": "17",


### PR DESCRIPTION
A recent change switched from shell version 40 to 41, which breaks compatibility with 40 - it will now only load in 41.
Unless there are actual incompatibilities, the shell version should include all versions which actually work, not only the latest.