### PR TITLE
Added checking app for null

### DIFF
--- a/AppManager.js
+++ b/AppManager.js
@@ -73,7 +73,7 @@ function getTrayApp(icon) {
 		var i = 1;
 		for (let lookup of searchedApps[0]) {
 			let app = AppSystem.get_default().lookup_app(lookup);
-			if (app.get_windows() != "" || i == searchedApps[0].length) {
+			if (app && (app.get_windows() != "" || i == searchedApps[0].length)) {
 				return app;
 			}
 			i++;


### PR DESCRIPTION
Fixed the error on adding the Telegram Desktop icon: 
```
JS ERROR: TypeError: app is null
getTrayApp@/trayIconsReloaded@selfmade.pl/AppManager.js:77:8
getAppSetting@/trayIconsReloaded@selfmade.pl/AppManager.js:54:28
addIcon@/trayIconsReloaded@selfmade.pl/TrayIndicator.js:51:32
_onIconAdded@/trayIconsReloaded@selfmade.pl/extension.js:19:71
```
Maybe it fixes other bugs #64, #66