### PR TITLE
Support for GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-	"shell-version": ["41"],
+	"shell-version": ["42"],
 	"uuid": "trayIconsReloaded@selfmade.pl",
 	"url": "https://github.com/MartinPL/Tray-Icons-Reloaded",
 	"version": "21",

--- a/preferences/Prefs.js
+++ b/preferences/Prefs.js
@@ -41,7 +41,6 @@ var Prefs = GObject.registerClass(
 
 			this.connect("realize", () => {
 				const window = this.get_root();
-				window.set_titlebar(this._headerBar);
 			});
 
 			let provider = new Gtk.CssProvider();


### PR DESCRIPTION
Using get_titlebar and set_titlebar is not supported anymore and will result in a crash.
