### PR TITLE
Hide empty overflow menu

### DIFF
--- a/TrayIndicator.js
+++ b/TrayIndicator.js
@@ -123,11 +123,13 @@ var TrayIndicator = GObject.registerClass(
 				this._icon.visible = true;
 				this.reactive = true;
 				this.style_class = "panel-button TrayIndicator";
+				this._menuItem.show();
 			} else {
 				this._overflow = false;
 				this._icon.visible = false;
 				this.reactive = false;
 				this.style_class = "TrayIndicator";
+				this._menuItem.hide();
 			}
 
 			if (this._icons.length) {


### PR DESCRIPTION
Hi,
When the extension is not in overflow mode, an empty menu is shown when opening another menu in the panel and moving the mouse over the extension. The issue occurs on Arch Linux with GNOME 42.1 and version 23 of the extension but not on Ubuntu 20.04.4 LTS with GNOME 3.36.8 and version 9 of the extension.

This pull request fixes this issue by hiding the empty menu, or to be more precise the only item in the menu, when the extension is not in overflow mode.

Best regards,
Daniel