### PR TITLE
Support for opening tray apps on touch release

### DIFF
--- a/TrayIndicator.js
+++ b/TrayIndicator.js
@@ -81,6 +81,13 @@ export const TrayIndicator = GObject.registerClass(
 				button.destroy();
 			});
 
+			button.connect("touch-event", (actor, event) => {
+				this.menu.close();
+				if (event.type() == Clutter.EventType.TOUCH_END) {
+					this._appManager.leftClick(icon, event);
+				}
+			});
+
 			button.connect("button-release-event", (actor, event) => {
 				this.menu.close();
 				switch (event.get_button()) {


### PR DESCRIPTION
Pertaining to #67 : Partial support for touchscreen. Basically performing app opening/closing on touch release of the app icon on the tray similar to left click's functionality. 

It seems like for holding to perform right click, some timeouts has to be set(?), but that's for later.

Edited: A bit of note. I decided to only make this run when it is `Clutter.EventType.TOUCH_END` rather than how dash to panel did it with either `Clutter.EventType.TOUCH_END` or `Clutter.EventType.TOUCH_CANCEL`, in which for the latter I'm not sure 100% on what it does, but if my hunch is correct in that it is some kind of touch release due to some interruption, then I don't think the app should be opened up.